### PR TITLE
Update README to use npx for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,9 @@ A complete `react` boilerplate application with the following provided and confi
 
  To get started, you can either clone this repository and make a copy of the code, or use `degit` to do this for you which will result in a clean copy of the project with none of the git history (i.e. no `.git` folder).
 
- To use `degit` run:
+ To get started, run:
  ```
-npm install -g degit
- ```
-
- Then run:
- ```
-degit tomglenn/react-redux-boilerplate my-project-name
+npx degit tomglenn/react-redux-boilerplate my-project-name
  ```
 
  Once you have a copy of the boilerplate, you can run the following to open the app:


### PR DESCRIPTION
For any tools that are only needed occasionally, such as `degit` or `create-react-app`, I would recommend using `npx` rather than installing the module globally.

`npx` is a magic little tool installed by default with modern versions of `npm` that does two things:

- If you pass it the name of a module that is already installed in your local `node_modules`, it will run that version of the module. E.g. if you run `npx jest` and you have `jest` installed in your module, it will run that module without you having to have `jest` setup as a script in your `package.json`.
- If the module name you pass is not installed locally, it will pull down the latest version of that module then run it. And I think it should tidy itself up afterwards too.

Installing Node modules globally is a pain in the arse, because things get out of date - so these days using `npx` is normally the simpler approach.