### PR TITLE
Reformat spaces in Footer.js

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,15 +1,15 @@
 import React from 'react';
 
-const Header = () => (
+const Footer = () => (
   <footer>
     <p>
-      Created with{' '}
+      {'Created with '}
       <span role="img" aria-label="love">
         ❤️
-      </span>{' '}
-      by <a href="https://github.com/tomglenn">Tom Glenn</a>
+      </span>{' by '}
+      <a href="https://github.com/tomglenn">Tom Glenn</a>
     </p>
   </footer>
 );
 
-export default Header;
+export default Footer;


### PR DESCRIPTION
This is very much personal preference, so feel free to disagree!

When writing JSX you sometimes are forced to add spaces as a quoted JSX string - I have found that it is normally more readable if you merge any other bare strings that are either side into that quoted JSX string, as I have shown in the updated code.

Also, I fixed the component name in the file, from `Header` to `Footer`.